### PR TITLE
Fix staging API URL and CORS for Azure deployment

### DIFF
--- a/.github/workflows/main_campuspe-web-staging.yml
+++ b/.github/workflows/main_campuspe-web-staging.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build Web app
         working-directory: ./apps/web
         env:
-          NEXT_PUBLIC_API_URL: https://campuspe-api-staging.azurewebsites.net
+          NEXT_PUBLIC_API_URL: https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net
         run: |
           echo "Setting environment variables for build..."
           echo "NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL"
@@ -66,7 +66,7 @@ jobs:
             echo "✅ No localhost:5001 found in build files"
           fi
 
-          if grep -r "campuspe-api-staging.azurewebsites.net" .next/static/ 2>/dev/null; then
+          if grep -r "campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net" .next/static/ 2>/dev/null; then
             echo "✅ Azure API URL found in build files"
           else
             echo "⚠️  WARNING: Azure API URL not found in build files"

--- a/AZURE_DEPLOYMENT_GUIDE.md
+++ b/AZURE_DEPLOYMENT_GUIDE.md
@@ -30,14 +30,14 @@ This guide will help you deploy the CampusPe platform (API + Web) to Azure App S
    PORT=80
    HOST=0.0.0.0
    NODE_ENV=production
-   CORS_ORIGIN=https://campuspe-web-staging.azurewebsites.net
+    CORS_ORIGIN=https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
    JWT_SECRET=your-super-secure-jwt-secret-for-staging
    CLAUDE_API_KEY=your-claude-api-key
    BUNNY_STORAGE_ZONE_NAME=your-storage-zone
    BUNNY_STORAGE_ACCESS_KEY=your-access-key
    BUNNY_CDN_URL=https://your-zone.b-cdn.net
    WABB_API_KEY=your-wabb-api-key
-   WABB_WEBHOOK_URL=https://campuspe-api-staging.azurewebsites.net/api/webhook/whatsapp
+    WABB_WEBHOOK_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/webhook/whatsapp
    ```
 
 ### For Web Service (campuspe-web-staging):
@@ -51,7 +51,7 @@ This guide will help you deploy the CampusPe platform (API + Web) to Azure App S
    ```
    NODE_ENV=production
    PORT=80
-   NEXT_PUBLIC_API_URL=https://campuspe-api-staging.azurewebsites.net/api
+    NEXT_PUBLIC_API_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net
    NEXT_TELEMETRY_DISABLED=1
    ```
 
@@ -93,11 +93,11 @@ The deployment workflows need these secrets in your GitHub repository:
 
 ### API Health Check:
 
-Visit: `https://campuspe-api-staging.azurewebsites.net/health`
+Visit: `https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/health`
 
 ### Web Application:
 
-Visit: `https://campuspe-web-staging.azurewebsites.net`
+Visit: `https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net`
 
 ## Troubleshooting
 

--- a/AZURE_ENV_CONFIG.md
+++ b/AZURE_ENV_CONFIG.md
@@ -18,7 +18,7 @@ HOST=0.0.0.0
 NODE_ENV=production
 
 # CORS Configuration (CRITICAL - this fixes the login/register errors)
-CORS_ORIGIN=https://campuspe-web-staging.azurewebsites.net,https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
+CORS_ORIGIN=https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
 
 # JWT Configuration
 JWT_SECRET=your-super-secure-jwt-secret-for-staging
@@ -32,7 +32,7 @@ BUNNY_STORAGE_ZONE_NAME=your-storage-zone
 BUNNY_STORAGE_ACCESS_KEY=your-access-key
 BUNNY_CDN_URL=https://your-zone.b-cdn.net
 WABB_API_KEY=your-wabb-api-key
-WABB_WEBHOOK_URL=https://campuspe-api-staging.azurewebsites.net/api/webhook/whatsapp
+WABB_WEBHOOK_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/webhook/whatsapp
 ```
 
 ### 🌐 Web Service (campuspe-web-staging)
@@ -47,7 +47,7 @@ NODE_ENV=production
 PORT=80
 
 # API Configuration (CRITICAL - this fixes the API connection)
-NEXT_PUBLIC_API_URL=https://campuspe-api-staging.azurewebsites.net/api
+NEXT_PUBLIC_API_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net
 
 # Optimization
 NEXT_TELEMETRY_DISABLED=1
@@ -55,9 +55,8 @@ NEXT_TELEMETRY_DISABLED=1
 
 ## 🚨 CRITICAL NOTES:
 
-1. **CORS_ORIGIN**: I've included both domain formats:
-   - `campuspe-web-staging.azurewebsites.net` (short form)
-   - `campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net` (full form)
+1. **CORS_ORIGIN**: Use your web app domain:
+    - `campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net`
 
 2. **NEXT_PUBLIC_API_URL**: Must point to your Azure API service, not localhost
 
@@ -69,15 +68,15 @@ NEXT_TELEMETRY_DISABLED=1
 ## 🔍 How to Verify Fix:
 
 1. **Check API CORS**:
-   - Visit: https://campuspe-api-staging.azurewebsites.net/health
+   - Visit: https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/health
    - Should return API status
 
 2. **Check Web App API Connection**:
-   - Visit: https://campuspe-web-staging.azurewebsites.net/login
+   - Visit: https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net/login
    - Try to login - should no longer show CORS or localhost errors
 
 3. **Browser Console**:
-   - Should show requests to `campuspe-api-staging.azurewebsites.net` instead of `localhost:5001`
+   - Should show requests to `campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net` instead of `localhost:5001`
 
 ## 📋 Step-by-Step Instructions:
 

--- a/AZURE_PERMISSIONS_FIXED_MANUAL_SETUP.md
+++ b/AZURE_PERMISSIONS_FIXED_MANUAL_SETUP.md
@@ -15,7 +15,7 @@
 The malformed URLs with commas suggest multiple environment variable sources in Azure:
 
 ```
-https://campuspe-api-staging.azurewebsites.net/api,https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/jobs
+https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api,https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/jobs
 ```
 
 **You need to manually clear conflicting environment variables in Azure Portal:**
@@ -30,7 +30,7 @@ https://campuspe-api-staging.azurewebsites.net/api,https://campuspe-api-staging-
 4. **Set clean values** (if needed):
 
    ```
-   NEXT_PUBLIC_API_URL = https://campuspe-api-staging.azurewebsites.net/api
+    NEXT_PUBLIC_API_URL = https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net
    NODE_ENV = production
    PORT = 80
    ```

--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -27,14 +27,14 @@ MONGODB_URI=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/campuspe-s
 PORT=80
 HOST=0.0.0.0
 NODE_ENV=production
-CORS_ORIGIN=https://campuspe-web-staging.azurewebsites.net
+ CORS_ORIGIN=https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
 JWT_SECRET=your-super-secure-jwt-secret
 CLAUDE_API_KEY=your-claude-api-key
 BUNNY_STORAGE_ZONE_NAME=your-storage-zone
 BUNNY_STORAGE_ACCESS_KEY=your-access-key
 BUNNY_CDN_URL=https://your-zone.b-cdn.net
 WABB_API_KEY=your-wabb-api-key
-WABB_WEBHOOK_URL=https://campuspe-api-staging.azurewebsites.net/api/webhook/whatsapp
+ WABB_WEBHOOK_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/webhook/whatsapp
 ```
 
 ### 2. Web Service (campuspe-web-staging)
@@ -51,7 +51,7 @@ In Azure Portal > App Services > campuspe-web-staging > Configuration:
 ```
 NODE_ENV=production
 PORT=80
-NEXT_PUBLIC_API_URL=https://campuspe-api-staging.azurewebsites.net/api
+ NEXT_PUBLIC_API_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net
 NEXT_TELEMETRY_DISABLED=1
 ```
 
@@ -100,8 +100,8 @@ The following secrets should already be configured in your GitHub repository (th
 
 After deployment, check:
 
-- API Health: https://campuspe-api-staging.azurewebsites.net/health
-- Web App: https://campuspe-web-staging.azurewebsites.net
+- API Health: https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/health
+- Web App: https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
 - Azure Portal logs for any errors
 
 ## 🔄 Next Deployment

--- a/DEPLOYMENT_STATUS.md
+++ b/DEPLOYMENT_STATUS.md
@@ -34,13 +34,13 @@ The deployments work, but the applications are configured for local development,
 
 **API Service:**
 
-- `CORS_ORIGIN=https://campuspe-web-staging.azurewebsites.net,https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net`
+- `CORS_ORIGIN=https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net`
 - `MONGODB_URI=your-mongodb-connection-string`
 - `JWT_SECRET=your-jwt-secret`
 
 **Web Service:**
 
-- `NEXT_PUBLIC_API_URL=https://campuspe-api-staging.azurewebsites.net/api`## Next Steps
+- `NEXT_PUBLIC_API_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net`## Next Steps
 
 ### 1. Trigger New Web Deployment
 
@@ -65,7 +65,7 @@ In Azure Portal > campuspe-web-staging > Configuration:
 ```
 NODE_ENV=production
 PORT=80
-NEXT_PUBLIC_API_URL=https://campuspe-api-staging.azurewebsites.net/api
+  NEXT_PUBLIC_API_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net
 NEXT_TELEMETRY_DISABLED=1
 ```
 
@@ -73,7 +73,7 @@ NEXT_TELEMETRY_DISABLED=1
 
 After successful deployment:
 
-- Visit: https://campuspe-web-staging.azurewebsites.net
+- Visit: https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
 - Check Azure App Service logs for any runtime errors
 - Run the verification script: `./verify-deployment.sh`
 
@@ -118,8 +118,8 @@ App Services > campuspe-web-staging > Log stream
 
 ## Support URLs
 
-- API Health: https://campuspe-api-staging.azurewebsites.net/health
-- Web App: https://campuspe-web-staging.azurewebsites.net
+- API Health: https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/health
+- Web App: https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
 - Azure Portal: https://portal.azure.com
 
 ## What Changed

--- a/DEPLOYMENT_STATUS_CRITICAL_FIX.md
+++ b/DEPLOYMENT_STATUS_CRITICAL_FIX.md
@@ -2,7 +2,7 @@
 
 ### ✅ **CRITICAL ISSUE RESOLVED**
 
-**Problem**: Web application was calling `localhost:5001` instead of Azure API (`https://campuspe-api-staging.azurewebsites.net/api`) causing CORS errors.
+**Problem**: Web application was calling `localhost:5001` instead of Azure API (`https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api`) causing CORS errors.
 
 **Root Cause**: Next.js had **TWO DIFFERENT PATTERNS** for API calls:
 
@@ -58,10 +58,10 @@ components/ApprovalStatus.tsx (4 localhost URLs)
 
 #### **Immediate Tests** (After current deployment)
 
-1. 🔥 **Login Test**: Visit https://campuspe-web-staging.azurewebsites.net/login
+1. 🔥 **Login Test**: Visit https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net/login
    - Enter valid credentials
    - Check browser DevTools Network tab
-   - Should see calls to `https://campuspe-api-staging.azurewebsites.net/api/auth/login`
+   - Should see calls to `https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/auth/login`
    - Should NOT see `localhost:5001` calls
 
 2. 🔥 **Job Listing**: Visit /jobs
@@ -95,8 +95,8 @@ components/ApprovalStatus.tsx (4 localhost URLs)
 curl -s "https://api.github.com/repos/CampusPe/Campuspe_Staging/actions/runs" | grep "status"
 
 # Test Azure endpoints
-curl -I https://campuspe-api-staging.azurewebsites.net/health
-curl -I https://campuspe-web-staging.azurewebsites.net
+curl -I https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/health
+curl -I https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
 
 # Check built files for localhost (should show Azure URLs)
 grep -r "localhost:5001" .next/static/ || echo "No localhost found - SUCCESS!"

--- a/URGENT_DEPLOYMENT_FIXES_APPLIED.md
+++ b/URGENT_DEPLOYMENT_FIXES_APPLIED.md
@@ -14,14 +14,14 @@
 
 #### **Issue 2: Malformed API URLs with Commas**
 
-**Problem**: URLs like `https://campuspe-api-staging.azurewebsites.net/api,https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/jobs`
+**Problem**: URLs like `https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api,https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/jobs`
 
 **Root Cause**: Multiple environment variable sources in Azure creating comma-separated values
 
 **✅ Fix Applied**:
 
 - Added explicit Azure App Service environment variable setting step
-- Workflow now sets clean `NEXT_PUBLIC_API_URL="https://campuspe-api-staging.azurewebsites.net/api"`
+- Workflow now sets clean `NEXT_PUBLIC_API_URL="https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net"`
 - Prevents conflicts between different environment variable sources
 
 #### **Issue 3: Remaining Localhost Calls**
@@ -46,7 +46,7 @@
 - name: Set Azure App Service Environment Variables
   run: |
     az webapp config appsettings set --name campuspe-web-staging --resource-group campuspe-staging --settings \
-      NEXT_PUBLIC_API_URL="https://campuspe-api-staging.azurewebsites.net/api" \
+      NEXT_PUBLIC_API_URL="https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net" \
       NODE_ENV="production" \
       PORT="80" \
       NEXT_TELEMETRY_DISABLED="1"
@@ -67,8 +67,8 @@ After this deployment (Commit: be555f5):
 
 ```javascript
 // ❌ MALFORMED URLs
-GET https://campuspe-api-staging.azurewebsites.net/api,https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/jobs
-POST https://campuspe-api-staging.azurewebsites.net/api,https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/auth/login
+GET https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api,https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/jobs
+POST https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api,https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/auth/login
 
 // ❌ LOCALHOST CALLS
 GET http://localhost:5001/api/colleges net::ERR_CONNECTION_REFUSED
@@ -78,9 +78,9 @@ GET http://localhost:5001/api/colleges net::ERR_CONNECTION_REFUSED
 
 ```javascript
 // ✅ CLEAN URLs
-GET https://campuspe-api-staging.azurewebsites.net/api/jobs
-POST https://campuspe-api-staging.azurewebsites.net/api/auth/login
-GET https://campuspe-api-staging.azurewebsites.net/api/colleges
+GET https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/jobs
+POST https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/auth/login
+GET https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/colleges
 ```
 
 ### ⏱️ **DEPLOYMENT TIMELINE**
@@ -98,19 +98,19 @@ Once deployment completes:
 
    ```bash
    # Visit login page
-   https://campuspe-web-staging.azurewebsites.net/login
+   https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net/login
 
    # Check DevTools Console - should see:
    ✅ NO "localhost:5001" calls
    ✅ NO "ERR_NAME_NOT_RESOLVED" for malformed URLs
-   ✅ Clean API calls to campuspe-api-staging.azurewebsites.net
+   ✅ Clean API calls to campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net
    ```
 
 2. **🔥 Priority 2 - Student Registration**:
 
    ```bash
    # Visit student registration
-   https://campuspe-web-staging.azurewebsites.net/register/student
+   https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net/register/student
 
    # Should load college dropdown without errors
    ✅ NO "Error fetching colleges" message

--- a/URGENT_FIX_GUIDE.md
+++ b/URGENT_FIX_GUIDE.md
@@ -22,14 +22,14 @@
 
 ```
 Name: NEXT_PUBLIC_API_URL
-Value: campuspe-api-staging.azurewebsites.net/api  ❌ WRONG
+Value: campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net  ❌ WRONG
 ```
 
 **TO THIS:**
 
 ```
 Name: NEXT_PUBLIC_API_URL
-Value: https://campuspe-api-staging.azurewebsites.net/api  ✅ CORRECT
+Value: https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net  ✅ CORRECT
 ```
 
 ### 2. Fix API Service Critical Variables
@@ -43,7 +43,7 @@ MONGODB_URI=mongodb+srv://CampuspeAdmin:CampusPe@campuspestaging.adslpw.mongodb.
 NODE_ENV=production
 PORT=80
 HOST=0.0.0.0
-CORS_ORIGIN=https://campuspe-web-staging.azurewebsites.net,https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
+CORS_ORIGIN=https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
 JWT_SECRET=campuspe_super_secret_jwt_key_2025
 ```
 
@@ -57,7 +57,7 @@ JWT_SECRET=campuspe_super_secret_jwt_key_2025
 4. Click `Application settings` tab
 5. Find `NEXT_PUBLIC_API_URL`
 6. Click the pencil/edit icon
-7. Change value to: `https://campuspe-api-staging.azurewebsites.net/api`
+7. Change value to: `https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net`
 8. Click "OK"
 9. Click "Save" at the top
 10. Wait for restart (green checkmark)
@@ -72,14 +72,14 @@ JWT_SECRET=campuspe_super_secret_jwt_key_2025
 ### Step 3: Test the Fix
 
 1. Wait 2-3 minutes for both services to restart
-2. Visit: `https://campuspe-web-staging.azurewebsites.net/login`
+2. Visit: `https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net/login`
 3. Open browser developer tools (F12)
 4. Try to login
-5. Check Console tab - should now show requests to `campuspe-api-staging.azurewebsites.net` instead of `localhost:5001`
+5. Check Console tab - should now show requests to `campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net` instead of `localhost:5001`
 
 ## 🔍 Expected Results After Fix:
 
-✅ Web app calls: `https://campuspe-api-staging.azurewebsites.net/api/auth/login`  
+✅ Web app calls: `https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/auth/login`  
 ✅ No more localhost:5001 calls  
 ✅ No more CORS errors  
 ✅ API service shows proper response instead of "Application Error"  

--- a/apps/api/.env.azure
+++ b/apps/api/.env.azure
@@ -10,7 +10,7 @@ HOST=0.0.0.0
 NODE_ENV=production
 
 # CORS Configuration
-CORS_ORIGIN=https://campuspe-web-staging.azurewebsites.net
+CORS_ORIGIN=https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net
 
 # JWT Configuration
 JWT_SECRET=your-super-secure-jwt-secret-for-staging
@@ -28,7 +28,7 @@ BUNNY_CDN_URL=https://your-zone.b-cdn.net
 # WhatsApp (WABB) Configuration
 WABB_API_URL=https://api.wabb.in
 WABB_API_KEY=your-wabb-api-key
-WABB_WEBHOOK_URL=https://campuspe-api-staging.azurewebsites.net/api/webhook/whatsapp
+WABB_WEBHOOK_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/api/webhook/whatsapp
 
 # Azure Communication Services
 AZURE_COMMUNICATION_CONNECTION_STRING=your-azure-communication-connection-string

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -31,7 +31,10 @@ const HOST = process.env.HOST || 'localhost';
 app.use(cors({
   origin: process.env.CORS_ORIGIN ? 
     process.env.CORS_ORIGIN.split(',').map(origin => origin.trim()) : 
-    ['http://localhost:3000', 'https://campuspe-web-staging.azurewebsites.net'],
+      [
+        'http://localhost:3000',
+        'https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net'
+      ],
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization']

--- a/apps/web/.env.azure
+++ b/apps/web/.env.azure
@@ -6,7 +6,7 @@ NODE_ENV=production
 PORT=80
 
 # API Configuration
-NEXT_PUBLIC_API_URL=https://campuspe-api-staging.azurewebsites.net/api
+NEXT_PUBLIC_API_URL=https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net
 
 # Other Next.js optimizations
 NEXT_TELEMETRY_DISABLED=1

--- a/quick-diagnosis.sh
+++ b/quick-diagnosis.sh
@@ -19,7 +19,7 @@ fi
 
 echo ""
 echo "🔧 Testing API Service Status..."
-API_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "https://campuspe-api-staging.azurewebsites.net/health" 2>/dev/null)
+API_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net/health" 2>/dev/null)
 
 if [ "$API_HEALTH" = "200" ]; then
     echo "✅ API service is running correctly"

--- a/verify-azure-config.sh
+++ b/verify-azure-config.sh
@@ -11,8 +11,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-API_URL="https://campuspe-api-staging.azurewebsites.net"
-WEB_URL="https://campuspe-web-staging.azurewebsites.net"
+API_URL="https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net"
+WEB_URL="https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net"
 
 echo -e "\n${BLUE}📊 Checking API Health...${NC}"
 API_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "${API_URL}/health" || echo "000")
@@ -33,7 +33,7 @@ else
 fi
 
 echo -e "\n${BLUE}🔗 Testing API CORS Configuration...${NC}"
-CORS_TEST=$(curl -s -H "Origin: https://campuspe-web-staging.azurewebsites.net" \
+  CORS_TEST=$(curl -s -H "Origin: https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net" \
   -H "Access-Control-Request-Method: POST" \
   -H "Access-Control-Request-Headers: Content-Type" \
   -X OPTIONS "${API_URL}/api/auth/login" \
@@ -47,7 +47,7 @@ else
 fi
 
 echo -e "\n${BLUE}📱 Testing API Connectivity from Web Domain...${NC}"
-API_CONNECTIVITY=$(curl -s -H "Origin: https://campuspe-web-staging.azurewebsites.net" \
+  API_CONNECTIVITY=$(curl -s -H "Origin: https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net" \
   "${API_URL}/api/auth/health" \
   -w "%{http_code}" -o /dev/null || echo "000")
 
@@ -65,7 +65,7 @@ echo -e "Login Page: ${BLUE}${WEB_URL}/login${NC}"
 echo -e "\n${YELLOW}🛠️  Configuration Checklist:${NC}"
 echo -e "□ API Service environment variables configured"
 echo -e "□ Web Service environment variables configured"
-echo -e "□ CORS_ORIGIN includes both Azure domain formats"
+echo -e "□ CORS_ORIGIN includes web app domain"
 echo -e "□ NEXT_PUBLIC_API_URL points to Azure API service"
 echo -e "□ MongoDB connection string is valid"
 

--- a/verify-deployment.sh
+++ b/verify-deployment.sh
@@ -12,8 +12,8 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Configuration
-API_URL="https://campuspe-api-staging.azurewebsites.net"
-WEB_URL="https://campuspe-web-staging.azurewebsites.net"
+API_URL="https://campuspe-api-staging-hmfjgud5c6a7exe9.southindia-01.azurewebsites.net"
+WEB_URL="https://campuspe-web-staging-erd8dvb3ewcjc5g2.southindia-01.azurewebsites.net"
 
 echo -e "\n📊 Checking API Health..."
 API_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "${API_URL}/health" || echo "000")


### PR DESCRIPTION
## Summary
- point web app to the deployed Azure API host
- allow the staged web domain through API CORS and webhook settings
- update workflows, verification scripts, and docs for new Azure URLs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895a1b7bb608327a87b13ee40b0807d