### PR TITLE
fix(web): ensure DOCTYPE included

### DIFF
--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
## Summary
- add custom Next.js Document to guarantee `<!DOCTYPE html>` and prevent KaTeX quirks-mode warning

## Testing
- `npm run build:web`

------
https://chatgpt.com/codex/tasks/task_e_6896341b71148327bb9c512888eeef26