### PR TITLE
fix(web): ensure DOCTYPE included

### DIFF
--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/apps/web/startup.sh
+++ b/apps/web/startup.sh
@@ -13,15 +13,16 @@ export NODE_ENV=production
 
 echo "Environment: PORT=$PORT, HOST=$HOST, NODE_ENV=$NODE_ENV"
 
-# Install dependencies if missing (should not happen in production)
+# Install dependencies if missing
 if [ ! -d "node_modules" ]; then
     echo "Installing dependencies..."
-    npm install --only=production
+    npm install --include=dev
 fi
 
-# Check if Next.js build exists (should exist from GitHub Actions build)
+# Ensure Next.js build exists
 if [ ! -d ".next" ]; then
-    echo "ERROR: Next.js build not found! Building..."
+    echo "Next.js build not found! Installing dependencies and building..."
+    npm install --include=dev
     npm run build
 fi
 


### PR DESCRIPTION
## Summary
- add custom Next.js Document to guarantee `<!DOCTYPE html>` and prevent KaTeX quirks-mode warning
- install dev dependencies during startup so missing `.next` builds succeed

## Testing
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_6896341b71148327bb9c512888eeef26