### PR TITLE
fix(web): build Next.js if missing on startup

### DIFF
--- a/apps/web/server-azure.js
+++ b/apps/web/server-azure.js
@@ -18,10 +18,30 @@ console.log(`Node version: ${process.version}`);
 
 // Check for required files
 const fs = require('fs');
+const { execSync } = require('child_process');
 console.log('Checking required files...');
 console.log(`package.json exists: ${fs.existsSync('./package.json')}`);
 console.log(`next.config.js exists: ${fs.existsSync('./next.config.js')}`);
 console.log(`.next directory exists: ${fs.existsSync('./.next')}`);
+
+// Ensure Next.js build artifacts exist. If the .next directory is missing
+// (common on Azure when the build step was skipped), attempt a production
+// build on startup so the server can boot successfully.
+if (!fs.existsSync('./.next')) {
+  console.log('.next directory missing – running `npm run build`...');
+  try {
+    execSync('npm run build', { stdio: 'inherit' });
+  } catch (err) {
+    console.error('Failed to build Next.js application:', err);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync('./.next')) {
+    console.error('Build completed but .next directory still missing.');
+    process.exit(1);
+  }
+  console.log('.next directory generated successfully.');
+}
 
 if (fs.existsSync('./package.json')) {
   const pkg = require('./package.json');

--- a/apps/web/startup.sh
+++ b/apps/web/startup.sh
@@ -32,9 +32,12 @@ fi
 
 # Ensure Next.js build exists
 if [ ! -d ".next" ]; then
-    echo "❌ Next.js build not found! This is a critical error."
-    echo "The build should have been created during deployment."
-    exit 1
+    echo "❌ Next.js build not found! Attempting to build..."
+    npm run build
+    if [ ! -d ".next" ]; then
+        echo "❌ Build failed to produce .next directory."
+        exit 1
+    fi
 else
     echo "✅ Next.js build found"
 fi


### PR DESCRIPTION
## Summary
- run `npm run build` from the web server when `.next` is absent so Azure deployments have required Next.js artifacts

## Testing
- `npm run build`
- `npm test` (api) *(fails: 9 failing tests)*
- `npm test` (web) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689703307338832787ce706b112ee5e8