### PR TITLE
fix(web): build Next.js if missing on startup

### DIFF
--- a/apps/web/startup.sh
+++ b/apps/web/startup.sh
@@ -22,19 +22,22 @@ echo ".next directory: $([ -d ".next" ] && echo "✅ EXISTS" || echo "❌ MISSIN
 echo "package.json: $([ -f "package.json" ] && echo "✅ EXISTS" || echo "❌ MISSING")"
 echo "server-azure-debug.js: $([ -f "server-azure-debug.js" ] && echo "✅ EXISTS" || echo "❌ MISSING")"
 
-# Install dependencies if missing
-if [ ! -d "node_modules" ]; then
-    echo "Installing dependencies..."
-    npm install --only=production
+# Install dependencies if Next.js is missing
+if [ ! -d "node_modules/next" ]; then
+    echo "Installing dependencies (including dev)..."
+    npm ci --include=dev
 else
     echo "Dependencies already installed"
 fi
 
 # Ensure Next.js build exists
 if [ ! -d ".next" ]; then
-    echo "❌ Next.js build not found! This is a critical error."
-    echo "The build should have been created during deployment."
-    exit 1
+    echo "❌ Next.js build not found! Attempting to build..."
+    npm run build
+    if [ ! -d ".next" ]; then
+        echo "❌ Build failed to produce .next directory."
+        exit 1
+    fi
 else
     echo "✅ Next.js build found"
 fi


### PR DESCRIPTION
## Summary
- run `npm ci --include=dev` when `node_modules/next` is missing to restore dev dependencies before starting
- load Next.js only after ensuring dependencies and build artifacts exist so startup can self-heal on Azure

## Testing
- `npm run build`
- `npm test` (api) *(fails: 9 failing tests)*
- `npm test` (web) *(fails: No tests found)*
- `npm run test:db` *(fails: Cannot find module `scripts/test-mongodb-connection.js`)*
- `./debug-web-503.sh` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_689703307338832787ce706b112ee5e8