### PR TITLE
Use API base URL for OTP and registration requests

### DIFF
--- a/apps/web/pages/register/recruiter.tsx
+++ b/apps/web/pages/register/recruiter.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import Navbar from '../../components/Navbar';
 import Footer from '../../components/Footer';
 import axios from 'axios';
+import { API_BASE_URL, API_ENDPOINTS } from '../../utils/api';
 
 interface College {
   _id: string;
@@ -65,7 +66,9 @@ export default function RecruiterRegisterPage() {
 
   const fetchColleges = async () => {
     try {
-      const response = await axios.get('http://localhost:5001/api/colleges');
+      const response = await axios.get(
+        `${API_BASE_URL}${API_ENDPOINTS.COLLEGES}`
+      );
       setColleges(response.data);
     } catch (error) {
       console.error('Error fetching colleges:', error);
@@ -134,7 +137,10 @@ export default function RecruiterRegisterPage() {
     setError('');
     try {
       // Check if email already exists
-      const emailCheckResponse = await axios.post('http://localhost:5001/api/auth/check-email', { email: formData.email });
+      const emailCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_EMAIL}`,
+        { email: formData.email }
+      );
       if (!emailCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
@@ -142,14 +148,17 @@ export default function RecruiterRegisterPage() {
       }
 
       // Check if phone number already exists
-      const phoneCheckResponse = await axios.post('http://localhost:5001/api/auth/check-phone', { phone: formData.phoneNumber });
+      const phoneCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_PHONE}`,
+        { phone: formData.phoneNumber }
+      );
       if (!phoneCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
         return;
       }
 
-      const response = await axios.post('http://localhost:5001/api/auth/send-otp', {
+      const response = await axios.post(`${API_BASE_URL}${API_ENDPOINTS.SEND_OTP}`, {
         phoneNumber: formData.phoneNumber,
         email: formData.email,
         userType: 'recruiter',
@@ -186,11 +195,14 @@ export default function RecruiterRegisterPage() {
 
     setLoading(true);
     try {
-      const response = await axios.post('http://localhost:5001/api/auth/verify-otp', {
-        otpId,
-        otp: formData.otp,
-        userType: 'recruiter'
-      });
+      const response = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.VERIFY_OTP}`,
+        {
+          otpId,
+          otp: formData.otp,
+          userType: 'recruiter'
+        }
+      );
 
       if (response.data.verified) {
         setStep(2);
@@ -245,7 +257,10 @@ export default function RecruiterRegisterPage() {
         }
       };
 
-      const response = await axios.post('http://localhost:5001/api/auth/register', registrationData);
+      const response = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.REGISTER}`,
+        registrationData
+      );
 
       localStorage.setItem('token', response.data.token);
       router.push('/dashboard/recruiter');

--- a/apps/web/pages/register/student.tsx
+++ b/apps/web/pages/register/student.tsx
@@ -160,14 +160,17 @@ const sendOTP = async () => {
       }
 
       // Check if phone number already exists
-      const phoneCheckResponse = await axios.post('http://localhost:5001/api/auth/check-phone', { phone: formData.phoneNumber });
+      const phoneCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_PHONE}`,
+        { phone: formData.phoneNumber }
+      );
       if (!phoneCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
         return;
       }
 
-      const response = await axios.post('http://localhost:5001/api/auth/send-otp', {
+      const response = await axios.post(`${API_BASE_URL}${API_ENDPOINTS.SEND_OTP}`, {
         phoneNumber: formData.phoneNumber,
         userType: 'student',
         preferredMethod: otpMethod,
@@ -217,7 +220,10 @@ const sendOTP = async () => {
       }
 
       console.log('Verifying OTP with payload:', payload);
-      const response = await axios.post('http://localhost:5001/api/auth/verify-otp', payload);
+      const response = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.VERIFY_OTP}`,
+        payload
+      );
 
       if (response.data.verified) {
         setStep(2);
@@ -271,7 +277,10 @@ const sendOTP = async () => {
       }
 
       // Check if email already exists before submitting registration
-      const emailCheckResponse = await axios.post('http://localhost:5001/api/auth/check-email', { email: formData.email });
+      const emailCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_EMAIL}`,
+        { email: formData.email }
+      );
       if (!emailCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
@@ -279,7 +288,10 @@ const sendOTP = async () => {
       }
 
       // Check if phone number already exists before submitting registration
-      const phoneCheckResponse = await axios.post('http://localhost:5001/api/auth/check-phone', { phone: formData.phoneNumber });
+      const phoneCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_PHONE}`,
+        { phone: formData.phoneNumber }
+      );
       if (!phoneCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
@@ -322,7 +334,10 @@ const registrationData = {
 };
 
       console.log('Submitting registration:', registrationData);
-      const response = await axios.post('http://localhost:5001/api/auth/register', registrationData);
+      const response = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.REGISTER}`,
+        registrationData
+      );
       
       console.log('Registration response:', response.data);
       if (response.data && response.data.token) {


### PR DESCRIPTION
## Summary
- Use environment-driven API base URL for phone/email checks, OTP flows, and registration in student and recruiter signup pages
- Remove hard-coded localhost references to prevent 404 and network errors on staging

## Testing
- `npm test` (fails: Missing script)
- `cd apps/web && npm test` (fails: No tests found)
- `cd apps/api && npm test` (fails: Test suite failed)


------
https://chatgpt.com/codex/tasks/task_e_689970e0bb388327919088d78c0558bd