### PR TITLE
Use API base URL for OTP and registration requests

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.24.3",
         "@azure/communication-email": "^1.0.0",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
         "@types/puppeteer": "^5.4.7",
         "axios": "^1.10.0",
         "bcryptjs": "^2.4.3",
@@ -28,8 +30,6 @@
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
-        "@types/cors": "^2.8.17",
-        "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/multer": "^1.4.13",
@@ -1466,7 +1466,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -1477,7 +1476,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1494,7 +1492,6 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1504,7 +1501,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
       "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1517,7 +1513,6 @@
       "version": "4.19.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
       "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1540,7 +1535,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -1603,7 +1597,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -1665,7 +1658,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/raf": {
@@ -1679,14 +1671,12 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
       "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -1697,7 +1687,6 @@
       "version": "1.15.8",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
       "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,8 @@
     "@types/puppeteer": "^5.4.7",
     "axios": "^1.10.0",
     "bcryptjs": "^2.4.3",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
     "cors": "^2.8.5",
     "csv-parse": "^6.0.0",
     "dotenv": "^16.3.1",
@@ -32,8 +34,6 @@
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
-    "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/multer": "^1.4.13",

--- a/apps/web/pages/register/recruiter.tsx
+++ b/apps/web/pages/register/recruiter.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import Navbar from '../../components/Navbar';
 import Footer from '../../components/Footer';
 import axios from 'axios';
+import { API_BASE_URL, API_ENDPOINTS } from '../../utils/api';
 
 interface College {
   _id: string;
@@ -65,7 +66,9 @@ export default function RecruiterRegisterPage() {
 
   const fetchColleges = async () => {
     try {
-      const response = await axios.get('http://localhost:5001/api/colleges');
+      const response = await axios.get(
+        `${API_BASE_URL}${API_ENDPOINTS.COLLEGES}`
+      );
       setColleges(response.data);
     } catch (error) {
       console.error('Error fetching colleges:', error);
@@ -134,7 +137,10 @@ export default function RecruiterRegisterPage() {
     setError('');
     try {
       // Check if email already exists
-      const emailCheckResponse = await axios.post('http://localhost:5001/api/auth/check-email', { email: formData.email });
+      const emailCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_EMAIL}`,
+        { email: formData.email }
+      );
       if (!emailCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
@@ -142,14 +148,17 @@ export default function RecruiterRegisterPage() {
       }
 
       // Check if phone number already exists
-      const phoneCheckResponse = await axios.post('http://localhost:5001/api/auth/check-phone', { phone: formData.phoneNumber });
+      const phoneCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_PHONE}`,
+        { phone: formData.phoneNumber }
+      );
       if (!phoneCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
         return;
       }
 
-      const response = await axios.post('http://localhost:5001/api/auth/send-otp', {
+      const response = await axios.post(`${API_BASE_URL}${API_ENDPOINTS.SEND_OTP}`, {
         phoneNumber: formData.phoneNumber,
         email: formData.email,
         userType: 'recruiter',
@@ -186,11 +195,14 @@ export default function RecruiterRegisterPage() {
 
     setLoading(true);
     try {
-      const response = await axios.post('http://localhost:5001/api/auth/verify-otp', {
-        otpId,
-        otp: formData.otp,
-        userType: 'recruiter'
-      });
+      const response = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.VERIFY_OTP}`,
+        {
+          otpId,
+          otp: formData.otp,
+          userType: 'recruiter'
+        }
+      );
 
       if (response.data.verified) {
         setStep(2);
@@ -245,7 +257,10 @@ export default function RecruiterRegisterPage() {
         }
       };
 
-      const response = await axios.post('http://localhost:5001/api/auth/register', registrationData);
+      const response = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.REGISTER}`,
+        registrationData
+      );
 
       localStorage.setItem('token', response.data.token);
       router.push('/dashboard/recruiter');

--- a/apps/web/pages/register/student.tsx
+++ b/apps/web/pages/register/student.tsx
@@ -160,14 +160,17 @@ const sendOTP = async () => {
       }
 
       // Check if phone number already exists
-      const phoneCheckResponse = await axios.post('http://localhost:5001/api/auth/check-phone', { phone: formData.phoneNumber });
+      const phoneCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_PHONE}`,
+        { phone: formData.phoneNumber }
+      );
       if (!phoneCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
         return;
       }
 
-      const response = await axios.post('http://localhost:5001/api/auth/send-otp', {
+      const response = await axios.post(`${API_BASE_URL}${API_ENDPOINTS.SEND_OTP}`, {
         phoneNumber: formData.phoneNumber,
         userType: 'student',
         preferredMethod: otpMethod,
@@ -217,7 +220,10 @@ const sendOTP = async () => {
       }
 
       console.log('Verifying OTP with payload:', payload);
-      const response = await axios.post('http://localhost:5001/api/auth/verify-otp', payload);
+      const response = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.VERIFY_OTP}`,
+        payload
+      );
 
       if (response.data.verified) {
         setStep(2);
@@ -271,7 +277,10 @@ const sendOTP = async () => {
       }
 
       // Check if email already exists before submitting registration
-      const emailCheckResponse = await axios.post('http://localhost:5001/api/auth/check-email', { email: formData.email });
+      const emailCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_EMAIL}`,
+        { email: formData.email }
+      );
       if (!emailCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
@@ -279,7 +288,10 @@ const sendOTP = async () => {
       }
 
       // Check if phone number already exists before submitting registration
-      const phoneCheckResponse = await axios.post('http://localhost:5001/api/auth/check-phone', { phone: formData.phoneNumber });
+      const phoneCheckResponse = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.CHECK_PHONE}`,
+        { phone: formData.phoneNumber }
+      );
       if (!phoneCheckResponse.data.available) {
         router.push('/login');
         setLoading(false);
@@ -322,7 +334,10 @@ const registrationData = {
 };
 
       console.log('Submitting registration:', registrationData);
-      const response = await axios.post('http://localhost:5001/api/auth/register', registrationData);
+      const response = await axios.post(
+        `${API_BASE_URL}${API_ENDPOINTS.REGISTER}`,
+        registrationData
+      );
       
       console.log('Registration response:', response.data);
       if (response.data && response.data.token) {


### PR DESCRIPTION
## Summary
- Use environment-driven API base URL for phone/email checks, OTP flows, and registration in student and recruiter signup pages
- Install express and cors type definitions as production dependencies to resolve build errors

## Testing
- `npm test` (fails: Missing script)
- `cd apps/web && npm test` (fails: No tests found)
- `cd apps/api && npm test` (fails: Test suites failed)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689970e0bb388327919088d78c0558bd